### PR TITLE
Revert to dgo v240

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -19,7 +19,7 @@ package dgman
 import (
 	"bytes"
 
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	"github.com/pkg/errors"
 )
 

--- a/examples/authapp/main.go
+++ b/examples/authapp/main.go
@@ -4,13 +4,13 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/dgraph-io/dgo/v250"
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	"github.com/dolan-in/dgman/v2"
 	"google.golang.org/grpc"
 )
 
-func newDgraphClient() dgo.Client {
+func newDgraphClient() *dgo.Dgraph {
 	d, err := grpc.Dial("localhost:9080", grpc.WithInsecure())
 	if err != nil {
 		panic(err)
@@ -21,7 +21,7 @@ func newDgraphClient() dgo.Client {
 	)
 }
 
-func newApi(dgoClient dgo.Client) *userAPI {
+func newApi(dgoClient *dgo.Dgraph) *userAPI {
 	return &userAPI{
 		store: &userStore{c: dgoClient},
 	}

--- a/examples/authapp/store.go
+++ b/examples/authapp/store.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/dgraph-io/dgo/v250"
+	"github.com/dgraph-io/dgo/v240"
 	"github.com/dolan-in/dgman/v2"
 )
 
@@ -40,7 +40,7 @@ type UserStore interface {
 }
 
 type userStore struct {
-	c dgo.Client
+	c *dgo.Dgraph
 }
 
 func (s *userStore) Create(ctx context.Context, user *User) error {

--- a/examples/mutate/main.go
+++ b/examples/mutate/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dgraph-io/dgo/v250"
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	"google.golang.org/grpc"
 
 	"github.com/dolan-in/dgman/v2"
@@ -48,7 +48,7 @@ type GeoLoc struct {
 	Coord []float64 `json:"coordinates"`
 }
 
-func dropAll(c dgo.Client) {
+func dropAll(c *dgo.Dgraph) {
 	err := c.Alter(context.Background(), &api.Operation{DropAll: true})
 	if err != nil {
 		panic(err)

--- a/examples/schema/main.go
+++ b/examples/schema/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dgraph-io/dgo/v250"
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	"google.golang.org/grpc"
 
 	"github.com/dolan-in/dgman/v2"
@@ -44,7 +44,7 @@ type GeoLoc struct {
 	Coord []float64 `json:"coordinates"`
 }
 
-func dropAll(c dgo.Client) {
+func dropAll(c *dgo.Dgraph) {
 	err := c.Alter(context.Background(), &api.Operation{DropAll: true})
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/dolan-in/dgman/v2
 
 require (
-	github.com/dgraph-io/dgo/v250 v250.0.0-20250408160036-08ce38a1dd09
+	github.com/dgraph-io/dgo/v240 v240.2.0
 	github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71
 	github.com/json-iterator/go v1.1.12
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/dgo/v240 v240.2.0 h1:dX7CCx7OSPl38GQ7Pa6jUB1RN21tyNlYpjNFgOsqp7k=
+github.com/dgraph-io/dgo/v240 v240.2.0/go.mod h1:CyEuwJgQ8NoNjWbj2ZnvVFPixe5akCbWPR1O0fHpQ+U=
 github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71 h1:v3bErDrPApxsyBlz8/8nFTCb7Ai0wecA8TokfEHIQ80=
 github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71/go.mod h1:Y9TyDkSL5jQ18ZnDaSxOdCUhbb5SCeamqYFQ7LYxxFs=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/interface.go
+++ b/interface.go
@@ -19,7 +19,7 @@ package dgman
 import (
 	"context"
 
-	"github.com/dgraph-io/dgo/v250"
+	"github.com/dgraph-io/dgo/v240"
 )
 
 // TxnInterface provides interface for dgman.TxnContext
@@ -28,7 +28,7 @@ type TxnInterface interface {
 	Discard() error
 	SetCommitNow() *TxnContext
 	BestEffort() *TxnContext
-	Txn() dgo.Transaction
+	Txn() *dgo.Txn
 	WithContext(context.Context)
 	Context() context.Context
 	Mutate(data interface{}) ([]string, error)

--- a/mutate.go
+++ b/mutate.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	"github.com/dolan-in/reflectwalk"
 	"github.com/pkg/errors"
 )

--- a/query.go
+++ b/query.go
@@ -25,8 +25,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dgraph-io/dgo/v250"
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	"github.com/pkg/errors"
 )
 
@@ -42,7 +42,7 @@ type ParamFormatter interface {
 
 type QueryBlock struct {
 	ctx         context.Context
-	tx          dgo.Transaction
+	tx          *dgo.Txn
 	paramString string
 	vars        map[string]string
 	blocks      []*Query
@@ -181,7 +181,7 @@ type order struct {
 
 type Query struct {
 	ctx         context.Context
-	tx          dgo.Transaction
+	tx          *dgo.Txn
 	model       interface{}
 	name        string
 	as          string

--- a/schema.go
+++ b/schema.go
@@ -24,8 +24,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/dgraph-io/dgo/v250"
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	"github.com/kr/logfmt"
 )
 
@@ -331,7 +331,7 @@ func parseStructTag(tag string) (*rawSchema, error) {
 	return &schema, nil
 }
 
-func fetchExistingSchema(c dgo.Client) ([]*Schema, error) {
+func fetchExistingSchema(c *dgo.Dgraph) ([]*Schema, error) {
 	schemaQuery := `
 		schema {
 			type
@@ -373,7 +373,7 @@ type typeQueryResponse struct {
 	} `json:"types"`
 }
 
-func fetchExistingTypes(c dgo.Client, typeMap TypeMap) (TypeMap, error) {
+func fetchExistingTypes(c *dgo.Dgraph, typeMap TypeMap) (TypeMap, error) {
 	// get keys of typeMap
 	keys := make([]string, 0, len(typeMap))
 	for key := range typeMap {
@@ -405,7 +405,7 @@ func fetchExistingTypes(c dgo.Client, typeMap TypeMap) (TypeMap, error) {
 	return types, nil
 }
 
-func cleanExistingSchema(c dgo.Client, schemaMap SchemaMap) error {
+func cleanExistingSchema(c *dgo.Dgraph, schemaMap SchemaMap) error {
 	existingSchema, err := fetchExistingSchema(c)
 	if err != nil {
 		return err
@@ -426,7 +426,7 @@ func cleanExistingSchema(c dgo.Client, schemaMap SchemaMap) error {
 
 // CreateSchema generate indexes, schema, and types from struct models,
 // returns the created schema map and types, does not update duplicate/conflict predicates.
-func CreateSchema(c dgo.Client, models ...interface{}) (*TypeSchema, error) {
+func CreateSchema(c *dgo.Dgraph, models ...interface{}) (*TypeSchema, error) {
 	typeSchema := NewTypeSchema()
 	typeSchema.Marshal("", models...)
 
@@ -446,7 +446,7 @@ func CreateSchema(c dgo.Client, models ...interface{}) (*TypeSchema, error) {
 
 // MutateSchema generate indexes and schema from struct models,
 // attempt updates for type, schema, and indexes.
-func MutateSchema(c dgo.Client, models ...interface{}) (*TypeSchema, error) {
+func MutateSchema(c *dgo.Dgraph, models ...interface{}) (*TypeSchema, error) {
 	typeSchema := NewTypeSchema()
 	typeSchema.Marshal("", models...)
 

--- a/txn.go
+++ b/txn.go
@@ -19,13 +19,13 @@ package dgman
 import (
 	"context"
 
-	"github.com/dgraph-io/dgo/v250"
+	"github.com/dgraph-io/dgo/v240"
 	"github.com/pkg/errors"
 )
 
 // TxnContext is dgo transaction coupled with context
 type TxnContext struct {
-	txn       dgo.Transaction
+	txn       *dgo.Txn
 	ctx       context.Context
 	commitNow bool
 }
@@ -47,7 +47,7 @@ func (t *TxnContext) BestEffort() *TxnContext {
 }
 
 // Txn returns the dgo transaction
-func (t *TxnContext) Txn() dgo.Transaction {
+func (t *TxnContext) Txn() *dgo.Txn {
 	return t.txn
 }
 
@@ -148,7 +148,7 @@ func (t *TxnContext) Query(query ...*Query) *QueryBlock {
 }
 
 // NewTxnContext creates a new transaction coupled with a context
-func NewTxnContext(ctx context.Context, c dgo.Client) *TxnContext {
+func NewTxnContext(ctx context.Context, c *dgo.Dgraph) *TxnContext {
 	return &TxnContext{
 		txn: c.NewTxn(),
 		ctx: ctx,
@@ -156,12 +156,12 @@ func NewTxnContext(ctx context.Context, c dgo.Client) *TxnContext {
 }
 
 // NewTxn creates a new transaction
-func NewTxn(c dgo.Client) *TxnContext {
+func NewTxn(c *dgo.Dgraph) *TxnContext {
 	return NewTxnContext(context.Background(), c)
 }
 
 // NewReadOnlyTxnContext creates a new read only transaction coupled with a context
-func NewReadOnlyTxnContext(ctx context.Context, c dgo.Client) *TxnContext {
+func NewReadOnlyTxnContext(ctx context.Context, c *dgo.Dgraph) *TxnContext {
 	return &TxnContext{
 		txn: c.NewReadOnlyTxn(),
 		ctx: ctx,
@@ -169,6 +169,6 @@ func NewReadOnlyTxnContext(ctx context.Context, c dgo.Client) *TxnContext {
 }
 
 // NewReadOnlyTxn creates a new read only transaction
-func NewReadOnlyTxn(c dgo.Client) *TxnContext {
+func NewReadOnlyTxn(c *dgo.Dgraph) *TxnContext {
 	return NewReadOnlyTxnContext(context.Background(), c)
 }

--- a/utils.go
+++ b/utils.go
@@ -22,14 +22,14 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/dgraph-io/dgo/v250"
-	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgo/v240"
+	"github.com/dgraph-io/dgo/v240/protos/api"
 	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-func newDgraphClient() dgo.Client {
+func newDgraphClient() *dgo.Dgraph {
 	client, err := dgo.Open("dgraph://localhost:9080")
 	if err != nil {
 		panic(err)
@@ -38,8 +38,8 @@ func newDgraphClient() dgo.Client {
 	return client
 }
 
-func dropAll(client ...dgo.Client) {
-	var c dgo.Client
+func dropAll(client ...*dgo.Dgraph) {
+	var c *dgo.Dgraph
 	if len(client) > 0 {
 		c = client[0]
 	} else {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Reverted dependency from dgo v250 to v240 across the codebase. This change ensures compatibility with existing systems while maintaining all functionality.

**Dependencies**
- Changed import paths from `github.com/dgraph-io/dgo/v250` to `github.com/dgraph-io/dgo/v240`
- Updated go.mod to use dgo v240.2.0 instead of v250

**Refactors**
- Updated type signatures from `dgo.Client` to `*dgo.Dgraph`
- Changed `dgo.Transaction` to `*dgo.Txn` in interfaces and function parameters
- Modified function signatures across the codebase to match v240 API

<!-- End of auto-generated description by mrge. -->

