### PR TITLE
Add new types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         dgraph alpha &
 
     - name: Run coverage
-      run: go test -race -coverprofile=coverage.out -covermode=atomic
+      run: go test -race -coverprofile=coverage.out -covermode=atomic -p 1 -parallel 1
     - name: Upload coverage to Codecov
       run: bash <(curl -s https://codecov.io/bash)
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 - Delete helpers (Delete n-quads generator, Delete Query, Delete Node, Delete Edge).
 
 ## Roadmap
-- Support for Dgraph's `@unique` directive [#8827](https://github.com/hypermodeinc/dgraph/pull/8827). This would
-replace the current unique checking logic.
 - Support for Dgraph v25's new namespace mechanism and other dgo v25 features.
 
 ## Table of Contents
@@ -74,7 +72,7 @@ If you need to define a custom name for the node type, you can define it on the 
 type CustomNodeType struct {
 	UID 	string 		`json:"uid,omitempty"`
 	Name 	string 		`json:"name,omitempty"`
-	DType	[]string 	`json:"dgraph.type" dgraph:"CustomNodeType"`
+	DType	[]string 	`json:"dgraph.type" dgraph:"MyNodeType"`
 }
 ```
 
@@ -748,6 +746,6 @@ Make sure you have a running `dgraph` cluster, and set the `DGMAN_TEST_DATABASE`
 
 Run the tests:
 
-```
-go test -v .
+```sh
+go test -v . -p 1 -parallel 1
 ```

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![Codecov](https://codecov.io/gh/dolan-in/dgman/branch/master/graph/badge.svg?token=89T0A95TWW)](https://codecov.io/gh/dolan-in/dgman)
 [![Go Reference](https://pkg.go.dev/badge/github.com/dolan-in/dgman/v2.svg)](https://pkg.go.dev/github.com/dolan-in/dgman/v2)
 
-***Dgman*** is a schema manager for [Dgraph](https://dgraph.io/) using the [Go Dgraph client (dgo)](https://github.com/dgraph-io/dgo), which manages Dgraph types, schema, and indexes from Go tags in struct definitions, allowing ORM-like convenience for developing Dgraph clients in Go.
+***Dgman*** is a schema manager for [Dgraph](https://dgraph.io/) using the [Go Dgraph client (dgo)](https://github.com/hypermode/dgo), which manages Dgraph types, schema, and indexes from Go tags in struct definitions, allowing ORM-like convenience for developing Dgraph clients in Go.
 
 ## Features
-- Create [types](https://docs.dgraph.io/query-language/#type-system) (Dgraph v1.1+), schemas, and indexes from struct tags.
+- Create [types](https://docs.hypermode.com/dgraph/dql/schema) (Dgraph v24.1+), schemas, and indexes from struct tags.
 - Detect conflicts from existing schema and defined schema.
 - Mutate Helpers (Mutate, MutateOrGet, Upsert).
 - Autoinject node type from struct.
@@ -15,7 +15,9 @@
 - Delete helpers (Delete n-quads generator, Delete Query, Delete Node, Delete Edge).
 
 ## Roadmap
-- Query builder
+- Support for Dgraph's `@unique` directive [#8827](https://github.com/hypermodeinc/dgraph/pull/8827). This would
+replace the current unique checking logic.
+- Support for Dgraph v25's new namespace mechanism and other dgo v25 features.
 
 ## Table of Contents
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -40,6 +40,7 @@ func createFlatStruct() FlatStruct {
 
 func BenchmarkMutateBasic(b *testing.B) {
 	c := newDgraphClient()
+	dropAll(c)
 	CreateSchema(c, FlatStruct{})
 	defer dropAll(c)
 
@@ -53,6 +54,7 @@ func BenchmarkMutateBasic(b *testing.B) {
 
 func BenchmarkMutate(b *testing.B) {
 	c := newDgraphClient()
+	dropAll(c)
 	CreateSchema(c, FlatStruct{})
 	defer dropAll(c)
 
@@ -66,6 +68,7 @@ func BenchmarkMutate(b *testing.B) {
 
 func BenchmarkMutateBasicNested(b *testing.B) {
 	c := newDgraphClient()
+	dropAll(c)
 	CreateSchema(c, TestUser{})
 	defer dropAll(c)
 
@@ -79,6 +82,7 @@ func BenchmarkMutateBasicNested(b *testing.B) {
 
 func BenchmarkMutateNested(b *testing.B) {
 	c := newDgraphClient()
+	dropAll(c)
 	CreateSchema(c, TestUser{})
 	defer dropAll(c)
 

--- a/delete_test.go
+++ b/delete_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestDelete(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -121,6 +122,7 @@ func TestDelete(t *testing.T) {
 
 func TestDeleteQuery(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -202,6 +204,7 @@ func TestDeleteQuery(t *testing.T) {
 
 func TestDeleteQueryCond(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -266,6 +269,7 @@ func TestDeleteQueryCond(t *testing.T) {
 func TestDeleteQueryCondUidFunc(t *testing.T) {
 	log.SetFlags(log.Llongfile)
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -350,6 +354,7 @@ func TestDeleteQueryCondUidFunc(t *testing.T) {
 
 func TestDeleteNode(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -385,6 +390,7 @@ func TestDeleteNode(t *testing.T) {
 
 func TestDeleteEdge(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/dolan-in/dgman/v2
 require (
 	github.com/dgraph-io/dgo/v240 v240.2.0
 	github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71
+	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/stdr v1.2.2
 	github.com/json-iterator/go v1.1.12
-	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.71.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/dgraph-io/dgo/v240 v240.2.0 h1:dX7CCx7OSPl38GQ7Pa6jUB1RN21tyNlYpjNFgO
 github.com/dgraph-io/dgo/v240 v240.2.0/go.mod h1:CyEuwJgQ8NoNjWbj2ZnvVFPixe5akCbWPR1O0fHpQ+U=
 github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71 h1:v3bErDrPApxsyBlz8/8nFTCb7Ai0wecA8TokfEHIQ80=
 github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71/go.mod h1:Y9TyDkSL5jQ18ZnDaSxOdCUhbb5SCeamqYFQ7LYxxFs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -18,8 +19,6 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
-github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/log.go
+++ b/log.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Dolan and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dgman
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
+)
+
+var (
+	logrLogger logr.Logger = stdr.New(nil)
+	logrOnce   sync.Once
+)
+
+// SetLogger sets the global logr.Logger for dgman
+func SetLogger(l logr.Logger) {
+	logrLogger = l
+}
+
+// Logger returns the current global logr.Logger
+func Logger() logr.Logger {
+	logrOnce.Do(func() {
+		if logrLogger.GetSink() == nil {
+			// Default to stdout logger if not set
+			logrLogger = stdr.New(nil)
+		}
+	})
+	return logrLogger
+}
+
+// init ensures the default logger is set to stdout
+func init() {
+	SetLogger(stdr.New(nil))
+}

--- a/mutate.go
+++ b/mutate.go
@@ -125,6 +125,8 @@ func (m *mutation) mutate() ([]string, error) {
 		return nil, errors.Wrap(err, "marshal setJSON failed")
 	}
 
+	Logger().WithName("dgman").V(3).Info("mutate", "setJSON", string(setJSON))
+
 	resp, err := m.txn.txn.Mutate(m.txn.ctx, &api.Mutation{
 		SetJson:   setJSON,
 		CommitNow: m.txn.commitNow,
@@ -147,6 +149,8 @@ func (m *mutation) do() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "generate request failed")
 	}
+
+	Logger().WithName("dgman").V(3).Info("do request", "request", m.request.String())
 
 	resp, err := m.txn.txn.Do(m.txn.ctx, &m.request)
 	if err != nil {

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -124,6 +124,7 @@ func createTestUser() TestUser {
 
 func TestMutationMutateBasic(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -143,6 +144,7 @@ func TestMutationMutateBasic(t *testing.T) {
 
 func TestMutationMutate(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -183,6 +185,7 @@ func TestMutationMutate(t *testing.T) {
 
 func TestMutationMutate_UpdateUnique(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -226,6 +229,7 @@ func TestMutationMutate_UpdateUnique(t *testing.T) {
 
 func TestMutationMutate_SetEdge(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -302,6 +306,7 @@ func TestMutationMutate_SetEdge(t *testing.T) {
 
 func TestMutationMutate_Nested(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -331,6 +336,7 @@ func TestMutationMutate_Nested(t *testing.T) {
 
 func TestMutationUpdate(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -376,6 +382,7 @@ func TestMutationUpdate(t *testing.T) {
 
 func TestMutationMutateOrGet(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -423,6 +430,7 @@ func TestMutationMutateOrGet(t *testing.T) {
 
 func TestMutationMutateOrGetNested(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -476,6 +484,7 @@ func TestMutationMutateOrGetNested(t *testing.T) {
 
 func TestMutationMutateOrGetMultipleUnique(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -529,6 +538,7 @@ func TestMutationMutateOrGetMultipleUnique(t *testing.T) {
 
 func TestMutationMutateOrGetMultipleUniqueNested(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -574,6 +584,7 @@ func TestMutationMutateOrGetMultipleUniqueNested(t *testing.T) {
 
 func TestMutationUpsert(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {
@@ -622,6 +633,7 @@ func TestMutationUpsert(t *testing.T) {
 
 func TestMutationUpsert_UniqueError(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestUser{})
 	if err != nil {

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -38,6 +38,8 @@ type TestUser struct {
 	Name            string        `json:"name,omitempty"`
 	Username        string        `json:"username,omitempty" dgraph:"index=term unique"`
 	Email           string        `json:"email,omitempty" dgraph:"index=term unique"`
+	Temp            float64       `json:"temperature,omitempty"`
+	ZeroTest        float64       `json:"zeroTest,omitempty"`
 	Schools         []TestSchool  `json:"schools,omitempty" dgraph:"count"`
 	SchoolsPtr      []*TestSchool `json:"schoolsPtr,omitempty" dgraph:"count"`
 	School          *TestSchool   `json:"school,omitempty"`
@@ -81,6 +83,8 @@ func createTestUser() TestUser {
 		Name:     "wildan",
 		Username: "wildan2711",
 		Email:    "wildan2711@gmail.com",
+		Temp:     37.5,
+		ZeroTest: 0.0,
 		School: &TestSchool{
 			Name:       "BSS",
 			Identifier: "bss",
@@ -138,8 +142,16 @@ func TestMutationMutateBasic(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 	assert.Len(t, uids, 9)
+
+	tx = NewReadOnlyTxn(c)
+	var result TestUser
+	err = tx.Get(&result).UID(user.UID).Node()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, user.Temp, result.Temp)
+	assert.Equal(t, 0.0, result.ZeroTest)
 }
 
 func TestMutationMutate(t *testing.T) {

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -17,7 +17,6 @@
 package dgman
 
 import (
-	"math/big"
 	"sort"
 	"testing"
 	"time"
@@ -39,9 +38,6 @@ type TestUser struct {
 	Name            string        `json:"name,omitempty"`
 	Username        string        `json:"username,omitempty" dgraph:"index=term unique"`
 	Email           string        `json:"email,omitempty" dgraph:"index=term unique"`
-	Temp            float64       `json:"temperature,omitempty"`
-	ZeroTest        float64       `json:"zeroTest,omitzero"`
-	Amount          *big.Float    `json:"amount,omitempty" dgraph:"index=bigfloat"`
 	Schools         []TestSchool  `json:"schools,omitempty" dgraph:"count"`
 	SchoolsPtr      []*TestSchool `json:"schoolsPtr,omitempty" dgraph:"count"`
 	School          *TestSchool   `json:"school,omitempty"`
@@ -85,8 +81,6 @@ func createTestUser() TestUser {
 		Name:     "wildan",
 		Username: "wildan2711",
 		Email:    "wildan2711@gmail.com",
-		Temp:     37.5,
-		Amount:   big.NewFloat(100.556),
 		School: &TestSchool{
 			Name:       "BSS",
 			Identifier: "bss",

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -17,6 +17,7 @@
 package dgman
 
 import (
+	"math/big"
 	"sort"
 	"testing"
 	"time"
@@ -40,6 +41,7 @@ type TestUser struct {
 	Email           string        `json:"email,omitempty" dgraph:"index=term unique"`
 	Temp            float64       `json:"temperature,omitempty"`
 	ZeroTest        float64       `json:"zeroTest,omitempty"`
+	Amount          *big.Float    `json:"amount,omitempty" dgraph:"index=bigfloat"`
 	Schools         []TestSchool  `json:"schools,omitempty" dgraph:"count"`
 	SchoolsPtr      []*TestSchool `json:"schoolsPtr,omitempty" dgraph:"count"`
 	School          *TestSchool   `json:"school,omitempty"`
@@ -85,6 +87,7 @@ func createTestUser() TestUser {
 		Email:    "wildan2711@gmail.com",
 		Temp:     37.5,
 		ZeroTest: 0.0,
+		Amount:   big.NewFloat(100.556),
 		School: &TestSchool{
 			Name:       "BSS",
 			Identifier: "bss",
@@ -143,15 +146,6 @@ func TestMutationMutateBasic(t *testing.T) {
 		t.Error(err)
 	}
 	assert.Len(t, uids, 9)
-
-	tx = NewReadOnlyTxn(c)
-	var result TestUser
-	err = tx.Get(&result).UID(user.UID).Node()
-	if err != nil {
-		t.Error(err)
-	}
-	assert.Equal(t, user.Temp, result.Temp)
-	assert.Equal(t, 0.0, result.ZeroTest)
 }
 
 func TestMutationMutate(t *testing.T) {
@@ -192,6 +186,49 @@ func TestMutationMutate(t *testing.T) {
 	sort.Sort(sortByUID)
 
 	assert.Equal(t, user, result)
+}
+
+func TestMutationFloats(t *testing.T) {
+	c := newDgraphClient()
+
+	_, err := CreateSchema(c, TestUser{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropAll(c)
+
+	tx := NewTxn(c).SetCommitNow()
+	user := createTestUser()
+
+	uids, err := tx.Mutate(&user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, uids, 9)
+
+	tx = NewReadOnlyTxn(c)
+	var result TestUser
+	err = tx.Get(&result).UID(user.UID).Node()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, user.Temp, result.Temp)
+	assert.Equal(t, 0.0, result.ZeroTest)
+
+	// Compare big.Float values properly using their comparison methods
+	expectedAmount := big.NewFloat(100.556)
+	// Option 1: Compare with Cmp method and tolerance
+	diff := new(big.Float).Sub(result.Amount, expectedAmount)
+	diff.Abs(diff)
+	tolerance := big.NewFloat(0.0001)
+	assert.True(t, diff.Cmp(tolerance) < 0,
+		"Expected %v but got %v, difference: %v",
+		expectedAmount.Text('f', 6), result.Amount.Text('f', 6), diff.Text('f', 6))
+
+	// Option 2: Compare string representations with specific precision
+	assert.Equal(t, expectedAmount.Text('f', 3), result.Amount.Text('f', 3),
+		"Float values should be equal when comparing with precision of 3 decimal places")
+
 }
 
 func TestMutationMutate_UpdateUnique(t *testing.T) {

--- a/query.go
+++ b/query.go
@@ -161,6 +161,8 @@ func (q *QueryBlock) String() string {
 func (q *QueryBlock) executeQuery() (result []byte, err error) {
 	queryString := q.String()
 
+	Logger().WithName("dgman").V(3).Info("executeQuery", "queryString", queryString)
+
 	var resp *api.Response
 	if q.vars != nil {
 		resp, err = q.tx.QueryWithVars(q.ctx, queryString, q.vars)
@@ -606,6 +608,7 @@ func (q *Query) String() string {
 func (q *Query) executeQuery() (result []byte, err error) {
 	queryString := q.String()
 
+	Logger().WithName("dgman").V(3).Info("execute query", "query", queryString)
 	var resp *api.Response
 	if q.vars != nil {
 		resp, err = q.tx.QueryWithVars(q.ctx, queryString, q.vars)

--- a/query_test.go
+++ b/query_test.go
@@ -49,6 +49,7 @@ func TestGetByUID(t *testing.T) {
 	}
 
 	c := newDgraphClient()
+	dropAll(c)
 	defer dropAll(c)
 
 	_, err := CreateSchema(c, &TestModel{})
@@ -83,6 +84,7 @@ func TestGetByFilter(t *testing.T) {
 	}
 
 	c := newDgraphClient()
+	dropAll(c)
 	if _, err := CreateSchema(c, source); err != nil {
 		t.Error(err)
 	}
@@ -146,6 +148,7 @@ func TestCascade(t *testing.T) {
 	}
 
 	c := newDgraphClient()
+	dropAll(c)
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -223,6 +226,7 @@ func TestFind(t *testing.T) {
 	}
 
 	c := newDgraphClient()
+	dropAll(c)
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -256,6 +260,7 @@ func TestGetByQuery(t *testing.T) {
 	}
 
 	c := newDgraphClient()
+	dropAll(c)
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -315,6 +320,7 @@ func TestGetAllWithDepth(t *testing.T) {
 	}
 
 	c := newDgraphClient()
+	dropAll(c)
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -353,6 +359,7 @@ func TestPagination(t *testing.T) {
 		})
 	}
 	c := newDgraphClient()
+	dropAll(c)
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -410,6 +417,7 @@ func TestOrder(t *testing.T) {
 		})
 	}
 	c := newDgraphClient()
+	dropAll(c)
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -467,6 +475,8 @@ func TestOrder(t *testing.T) {
 
 func TestQueryBlock(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
+
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -516,6 +526,8 @@ func TestQueryBlock(t *testing.T) {
 
 func TestGetNodesAndCount(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
+
 	if _, err := CreateSchema(c, &TestModel{}); err != nil {
 		t.Error(err)
 	}
@@ -688,4 +700,11 @@ func Test_parseQueryWithParams(t *testing.T) {
 			assert.Equal(t, tt.want, parseQueryWithParams(tt.args.query, tt.args.params))
 		})
 	}
+}
+
+func TestRootFunc(t *testing.T) {
+	query := NewQuery().Model(&TestItem{}).
+		RootFunc("similar_to(vector, 1, $vec)").
+		Vars("similar_to($vec)", map[string]string{"$vec": "[0.51, 0.39, 0.29, 0.19, 0.09]"})
+	fmt.Println(query.String())
 }

--- a/query_test.go
+++ b/query_test.go
@@ -428,7 +428,6 @@ func TestOrder(t *testing.T) {
 		Vars("getWithNames($name: string)", map[string]string{"$name": "wildan"}).
 		Filter("allofterms(name, $name)").
 		OrderAsc("age")
-	log.Println(query)
 	if err = query.Nodes(); err != nil {
 		t.Error(err)
 	}
@@ -437,11 +436,8 @@ func TestOrder(t *testing.T) {
 
 	result1 := &TestModel{}
 	NewReadOnlyTxn(c).Get(&result1).UID(models[0].UID).Node()
-	log.Printf("%+v", result1)
 
 	for i, r := range result {
-		log.Printf("%+v", models[i])
-		log.Printf("%+v", r)
 		assert.Equal(t, models[i], r)
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -706,5 +706,11 @@ func TestRootFunc(t *testing.T) {
 	query := NewQuery().Model(&TestItem{}).
 		RootFunc("similar_to(vector, 1, $vec)").
 		Vars("similar_to($vec)", map[string]string{"$vec": "[0.51, 0.39, 0.29, 0.19, 0.09]"})
-	fmt.Println(query.String())
+	assert.Equal(t, `query similar_to($vec){
+	data(func: similar_to(vector, 1, $vec)) @filter(has(dgraph.type)) {
+		uid
+		dgraph.type
+		expand(_all_)
+	}
+}`, query.String())
 }

--- a/schema.go
+++ b/schema.go
@@ -103,9 +103,9 @@ func (s Schema) String() string {
 	if s.Noconflict {
 		schema += "@noconflict "
 	}
-	if s.Metric != "" {
-		schema += fmt.Sprintf("@metric(%s) ", s.Metric)
-	}
+	//if s.Metric != "" {
+	//	schema += fmt.Sprintf("@metric(%s) ", s.Metric)
+	//}
 	return schema + "."
 }
 
@@ -404,9 +404,6 @@ func fetchExistingSchema(c *dgo.Dgraph) ([]*Schema, error) {
 		return nil, err
 	}
 
-	if false {
-		fmt.Println(schemas.Schema)
-	}
 	return schemas.Schema, nil
 }
 
@@ -505,10 +502,6 @@ func CreateSchema(c *dgo.Dgraph, models ...interface{}) (*TypeSchema, error) {
 	err := cleanExistingSchema(c, typeSchema.Schema)
 	if err != nil {
 		return nil, err
-	}
-
-	if false {
-		fmt.Println(typeSchema.String())
 	}
 
 	alterString := typeSchema.String()

--- a/schema.go
+++ b/schema.go
@@ -72,13 +72,21 @@ func (s Schema) String() string {
 	}
 	schema := fmt.Sprintf("%s: %s ", s.Predicate, t)
 	if s.Unique {
-		required := false
+		// Check if hash or exact already exists in tokenizers
+		hasHashOrExact := false
+		hasHash := false
+
 		for _, tokenizer := range s.Tokenizer {
-			if tokenizer == "hash" || tokenizer == "exact" {
-				required = true
+			if tokenizer == "hash" {
+				hasHash = true
+				hasHashOrExact = true
+			} else if tokenizer == "exact" {
+				hasHashOrExact = true
 			}
 		}
-		if !required {
+
+		// Only add hash if neither hash nor exact exists and hash isn't already present
+		if !hasHashOrExact && !hasHash {
 			s.Tokenizer = append(s.Tokenizer, "hash")
 		}
 	}

--- a/schema.go
+++ b/schema.go
@@ -21,8 +21,10 @@ import (
 
 	"fmt"
 	"log"
+	"math/big"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/dgraph-io/dgo/v240"
 	"github.com/dgraph-io/dgo/v240/protos/api"
@@ -237,10 +239,11 @@ func getSchemaType(fieldType reflect.Type) string {
 		sliceType := fieldType.Elem()
 		return fmt.Sprintf("[%s]", getSchemaType(sliceType))
 	case reflect.Struct:
-		switch fieldType.PkgPath() {
-		case "time":
-			// golang std time
+		switch fieldType {
+		case reflect.TypeOf(time.Time{}):
 			return "datetime"
+		case reflect.TypeOf(big.Float{}):
+			return "bigfloat"
 		default:
 			// one-to-one relation
 			return "uid"

--- a/schema.go
+++ b/schema.go
@@ -71,6 +71,17 @@ func (s Schema) String() string {
 		t = fmt.Sprintf("[%s]", t)
 	}
 	schema := fmt.Sprintf("%s: %s ", s.Predicate, t)
+	if s.Unique {
+		required := false
+		for _, tokenizer := range s.Tokenizer {
+			if tokenizer == "hash" || tokenizer == "exact" {
+				required = true
+			}
+		}
+		if !required {
+			s.Tokenizer = append(s.Tokenizer, "hash")
+		}
+	}
 	if s.Index {
 		schema += fmt.Sprintf("@index(%s) ", strings.Join(s.Tokenizer, ","))
 	} else if len(s.Tokenizer) > 0 {
@@ -83,6 +94,10 @@ func (s Schema) String() string {
 	}
 	if s.Upsert || s.Unique {
 		schema += "@upsert "
+		switch t {
+		case "int", "string":
+			schema += "@unique "
+		}
 	}
 	if s.Count {
 		schema += "@count "

--- a/schema.go
+++ b/schema.go
@@ -558,7 +558,12 @@ func CreateSchema(c *dgo.Dgraph, models ...interface{}) (*TypeSchema, error) {
 		for i := 0; i < modelType.NumField(); i++ {
 			field := modelType.Field(i)
 			jsonTag := field.Tag.Get("json")
-			if strings.HasPrefix(jsonTag, "dgraph.type") {
+
+			// Properly parse the JSON tag to extract just the field name
+			tagParts := strings.Split(jsonTag, ",")
+			fieldName := strings.TrimSpace(tagParts[0])
+
+			if fieldName == "dgraph.type" {
 				foundDType = true
 				break
 			}

--- a/schema_test.go
+++ b/schema_test.go
@@ -149,6 +149,7 @@ func TestGetNodeType(t *testing.T) {
 
 func TestCreateSchema(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 	defer dropAll(c)
 
 	firstSchema, err := CreateSchema(c, &User{})
@@ -196,6 +197,7 @@ func TestCreateSchema(t *testing.T) {
 
 func TestMutateSchema(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 	defer dropAll(c)
 
 	firstSchema, err := CreateSchema(c, &User{})
@@ -228,6 +230,7 @@ func TestMutateSchema(t *testing.T) {
 
 func TestOneToOneSchema(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 	defer dropAll(c)
 
 	schema, err := CreateSchema(c, &OneToOne{})
@@ -239,6 +242,7 @@ func TestOneToOneSchema(t *testing.T) {
 
 func Test_fetchExistingSchema(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 	defer dropAll(c)
 
 	schema, err := CreateSchema(c, &User{})
@@ -260,6 +264,7 @@ func Test_fetchExistingSchema(t *testing.T) {
 
 func Test_fetchExistingTypes(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 	defer dropAll(c)
 
 	schema, err := CreateSchema(c, &User{})
@@ -277,6 +282,7 @@ func Test_fetchExistingTypes(t *testing.T) {
 
 func TestMissingDType(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 	defer dropAll(c)
 
 	type SchemaTest struct {

--- a/schema_test.go
+++ b/schema_test.go
@@ -99,8 +99,8 @@ func TestMarshalSchema(t *testing.T) {
 	typeSchema := NewTypeSchema()
 	typeSchema.Marshal("", &User{})
 	types, schema := typeSchema.Types, typeSchema.Schema
-	assert.Equal(t, "username: string @index(hash) @upsert .", schema["username"].String())
-	assert.Equal(t, "email: string @index(hash) @upsert .", schema["email"].String())
+	assert.Equal(t, "username: string @index(hash) @upsert @unique .", schema["username"].String())
+	assert.Equal(t, "email: string @index(hash) @upsert @unique .", schema["email"].String())
 	assert.Equal(t, "noconflict: string @index(hash) @noconflict .", schema["noconflict"].String())
 	assert.Equal(t, "password: string .", schema["password"].String())
 	assert.Equal(t, "name: string @index(term) .", schema["name"].String())

--- a/schema_test.go
+++ b/schema_test.go
@@ -257,3 +257,15 @@ func Test_fetchExistingTypes(t *testing.T) {
 
 	assert.Len(t, types, 2)
 }
+
+func TestMissingDType(t *testing.T) {
+	c := newDgraphClient()
+	defer dropAll(c)
+
+	type SchemaTest struct {
+		UID  string `json:"uid,omitempty"`
+		Name string `json:"name,omitempty"`
+	}
+	_, err := CreateSchema(c, &SchemaTest{})
+	require.Error(t, err, "expected error due to missing required field DType []string `json:\"dgraph.type\"` in type SchemaTest")
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -38,32 +38,33 @@ type GeoLoc struct {
 }
 
 type User struct {
-	UID        string       `json:"uid,omitempty"`
-	Name       string       `json:"name,omitempty" dgraph:"index=term"`
-	Username   string       `json:"username,omitempty" dgraph:"index=hash unique"`
-	Email      string       `json:"email,omitempty" dgraph:"index=hash unique"`
-	Noconflict string       `json:"noconflict,omitempty" dgraph:"index=hash noconflict"`
-	Password   string       `json:"password,omitempty"`
-	Review     string       `json:"review" dgraph:"index=fulltext lang"`
-	ReviewEn   string       `json:"review@en"` // should not be parsed
-	ReviewDe   string       `json:"review@de"` // should not be parsed
-	Height     *int         `json:"height,omitempty"`
-	IsAdmin    bool         `json:"is_admin,omitempty"`
-	Temp       float64      `json:"temperature,omitempty"`
-	Amount     *big.Float     `json:"amount,omitempty" dgraph:"index=bigfloat"`
-	CustomTime CustomTime   `json:"custom_time,omitempty"`
-	Dob        *time.Time   `json:"dob,omitempty"`
-	Status     EnumType     `json:"status,omitempty" dgraph:"type=int"`
-	Created    *time.Time   `json:"created,omitempty"`
-	Dates      []time.Time  `json:"dates,omitempty"`
-	DatesPtr   []*time.Time `json:"dates_ptr,omitempty"`
-	Mobiles    []string     `json:"mobiles,omitempty"`
-	Schools    []School     `json:"schools,omitempty" dgraph:"count"`
-	SchoolsPtr []*School    `json:"schools_ptr,omitempty" dgraph:"count reverse"`
-	School     School       `json:"school" dgraph:"count reverse"`
-	SchoolPtr  *School      `json:"school_ptr" dgraph:"count reverse"`
-	Friends    []User       `json:"friends"`             // test recursive, will panic if fail
-	Object     interface{}  `json:"object" dgraph:"uid"` // test interface, will panic if fail
+	UID        string        `json:"uid,omitempty"`
+	Name       string        `json:"name,omitempty" dgraph:"index=term"`
+	Username   string        `json:"username,omitempty" dgraph:"index=hash unique"`
+	Email      string        `json:"email,omitempty" dgraph:"index=hash unique"`
+	Noconflict string        `json:"noconflict,omitempty" dgraph:"index=hash noconflict"`
+	Password   string        `json:"password,omitempty"`
+	Review     string        `json:"review" dgraph:"index=fulltext lang"`
+	ReviewEn   string        `json:"review@en"` // should not be parsed
+	ReviewDe   string        `json:"review@de"` // should not be parsed
+	Height     *int          `json:"height,omitempty"`
+	IsAdmin    bool          `json:"is_admin,omitempty"`
+	Temp       float64       `json:"temperature,omitempty"`
+	Amount     *big.Float    `json:"amount,omitempty" dgraph:"index=bigfloat"`
+	Vector     VectorFloat32 `json:"vector,omitempty" dgraph:"index=hnsw(metric=\"cosine\")"`
+	CustomTime CustomTime    `json:"custom_time,omitempty"`
+	Dob        *time.Time    `json:"dob,omitempty"`
+	Status     EnumType      `json:"status,omitempty" dgraph:"type=int"`
+	Created    *time.Time    `json:"created,omitempty"`
+	Dates      []time.Time   `json:"dates,omitempty"`
+	DatesPtr   []*time.Time  `json:"dates_ptr,omitempty"`
+	Mobiles    []string      `json:"mobiles,omitempty"`
+	Schools    []School      `json:"schools,omitempty" dgraph:"count"`
+	SchoolsPtr []*School     `json:"schools_ptr,omitempty" dgraph:"count reverse"`
+	School     School        `json:"school" dgraph:"count reverse"`
+	SchoolPtr  *School       `json:"school_ptr" dgraph:"count reverse"`
+	Friends    []User        `json:"friends"`             // test recursive, will panic if fail
+	Object     interface{}   `json:"object" dgraph:"uid"` // test interface, will panic if fail
 	*Anonymous
 	DType []string `json:"dgraph.type"`
 }
@@ -116,6 +117,7 @@ func TestMarshalSchema(t *testing.T) {
 	assert.Equal(t, "is_admin: bool .", schema["is_admin"].String())
 	assert.Equal(t, "temperature: float .", schema["temperature"].String())
 	assert.Equal(t, "amount: bigfloat @index(bigfloat) .", schema["amount"].String())
+	assert.Equal(t, "vector: float32vector @index(hnsw(metric:\"cosine\")) .", schema["vector"].String())
 	assert.Equal(t, "created: datetime .", schema["created"].String())
 	assert.Equal(t, "dates: [datetime] .", schema["dates"].String())
 	assert.Equal(t, "dates_ptr: [datetime] .", schema["dates_ptr"].String())

--- a/schema_test.go
+++ b/schema_test.go
@@ -353,6 +353,26 @@ func TestParseStructTag_Comprehensive(t *testing.T) {
 			expects: rawSchema{Predicate: "foo", Type: "uid"},
 			comment: "Predicate and type override",
 		},
+		{
+			tag:     "unique",
+			expects: rawSchema{Unique: true},
+			comment: "Unique flag only - should add hash tokenizer later",
+		},
+		{
+			tag:     "unique index=term",
+			expects: rawSchema{Unique: true, Index: "term"},
+			comment: "Unique with non-hash/exact tokenizer - should add hash tokenizer later",
+		},
+		{
+			tag:     "unique index=hash",
+			expects: rawSchema{Unique: true, Index: "hash"},
+			comment: "Unique with hash tokenizer - shouldn't add duplicate hash",
+		},
+		{
+			tag:     "unique index=exact",
+			expects: rawSchema{Unique: true, Index: "exact"},
+			comment: "Unique with exact tokenizer - doesn't need hash added",
+		},
 	}
 
 	for _, tt := range tests {

--- a/schema_test.go
+++ b/schema_test.go
@@ -17,11 +17,11 @@
 package dgman
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type EnumType int
@@ -38,33 +38,30 @@ type GeoLoc struct {
 }
 
 type User struct {
-	UID        string        `json:"uid,omitempty"`
-	Name       string        `json:"name,omitempty" dgraph:"index=term"`
-	Username   string        `json:"username,omitempty" dgraph:"index=hash unique"`
-	Email      string        `json:"email,omitempty" dgraph:"index=hash unique"`
-	Noconflict string        `json:"noconflict,omitempty" dgraph:"index=hash noconflict"`
-	Password   string        `json:"password,omitempty"`
-	Review     string        `json:"review" dgraph:"index=fulltext lang"`
-	ReviewEn   string        `json:"review@en"` // should not be parsed
-	ReviewDe   string        `json:"review@de"` // should not be parsed
-	Height     *int          `json:"height,omitempty"`
-	IsAdmin    bool          `json:"is_admin,omitempty"`
-	Temp       float64       `json:"temperature,omitempty"`
-	Amount     *big.Float    `json:"amount,omitempty" dgraph:"index=bigfloat"`
-	Vector     VectorFloat32 `json:"vector,omitempty" dgraph:"index=hnsw(metric=\"cosine\")"`
-	CustomTime CustomTime    `json:"custom_time,omitempty"`
-	Dob        *time.Time    `json:"dob,omitempty"`
-	Status     EnumType      `json:"status,omitempty" dgraph:"type=int"`
-	Created    *time.Time    `json:"created,omitempty"`
-	Dates      []time.Time   `json:"dates,omitempty"`
-	DatesPtr   []*time.Time  `json:"dates_ptr,omitempty"`
-	Mobiles    []string      `json:"mobiles,omitempty"`
-	Schools    []School      `json:"schools,omitempty" dgraph:"count"`
-	SchoolsPtr []*School     `json:"schools_ptr,omitempty" dgraph:"count reverse"`
-	School     School        `json:"school" dgraph:"count reverse"`
-	SchoolPtr  *School       `json:"school_ptr" dgraph:"count reverse"`
-	Friends    []User        `json:"friends"`             // test recursive, will panic if fail
-	Object     interface{}   `json:"object" dgraph:"uid"` // test interface, will panic if fail
+	UID        string       `json:"uid,omitempty"`
+	Name       string       `json:"name,omitempty" dgraph:"index=term"`
+	Username   string       `json:"username,omitempty" dgraph:"index=hash unique"`
+	Email      string       `json:"email,omitempty" dgraph:"index=hash unique"`
+	Noconflict string       `json:"noconflict,omitempty" dgraph:"index=hash noconflict"`
+	Password   string       `json:"password,omitempty"`
+	Review     string       `json:"review" dgraph:"index=fulltext lang"`
+	ReviewEn   string       `json:"review@en"` // should not be parsed
+	ReviewDe   string       `json:"review@de"` // should not be parsed
+	Height     *int         `json:"height,omitempty"`
+	IsAdmin    bool         `json:"is_admin,omitempty"`
+	CustomTime CustomTime   `json:"custom_time,omitempty"`
+	Dob        *time.Time   `json:"dob,omitempty"`
+	Status     EnumType     `json:"status,omitempty" dgraph:"type=int"`
+	Created    *time.Time   `json:"created,omitempty"`
+	Dates      []time.Time  `json:"dates,omitempty"`
+	DatesPtr   []*time.Time `json:"dates_ptr,omitempty"`
+	Mobiles    []string     `json:"mobiles,omitempty"`
+	Schools    []School     `json:"schools,omitempty" dgraph:"count"`
+	SchoolsPtr []*School    `json:"schools_ptr,omitempty" dgraph:"count reverse"`
+	School     School       `json:"school" dgraph:"count reverse"`
+	SchoolPtr  *School      `json:"school_ptr" dgraph:"count reverse"`
+	Friends    []User       `json:"friends"`             // test recursive, will panic if fail
+	Object     interface{}  `json:"object" dgraph:"uid"` // test interface, will panic if fail
 	*Anonymous
 	DType []string `json:"dgraph.type"`
 }
@@ -115,9 +112,6 @@ func TestMarshalSchema(t *testing.T) {
 	assert.Equal(t, "custom_time: datetime .", schema["custom_time"].String())
 	assert.Equal(t, "dob: datetime .", schema["dob"].String())
 	assert.Equal(t, "is_admin: bool .", schema["is_admin"].String())
-	assert.Equal(t, "temperature: float .", schema["temperature"].String())
-	assert.Equal(t, "amount: bigfloat @index(bigfloat) .", schema["amount"].String())
-	assert.Equal(t, "vector: float32vector @index(hnsw(metric:\"cosine\")) .", schema["vector"].String())
 	assert.Equal(t, "created: datetime .", schema["created"].String())
 	assert.Equal(t, "dates: [datetime] .", schema["dates"].String())
 	assert.Equal(t, "dates_ptr: [datetime] .", schema["dates_ptr"].String())

--- a/schema_test.go
+++ b/schema_test.go
@@ -280,6 +280,30 @@ func Test_fetchExistingTypes(t *testing.T) {
 	assert.Len(t, types, 2)
 }
 
+func Test_GetSchema(t *testing.T) {
+	c := newDgraphClient()
+	dropAll(c)
+	defer dropAll(c)
+
+	type SmallStruct struct {
+		UID   string   `json:"uid,omitempty"`
+		Name  string   `json:"name,omitempty" dgraph:"index=term"`
+		DType []string `json:"dgraph.type"`
+	}
+	_, err := CreateSchema(c, &SmallStruct{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	schema, err := GetSchema(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Contains(t, schema, "name: string @index(term) .")
+	assert.Contains(t, schema, "type SmallStruct {\n\tname\n}")
+}
+
 func TestMissingDType(t *testing.T) {
 	c := newDgraphClient()
 	dropAll(c)

--- a/schema_test.go
+++ b/schema_test.go
@@ -17,6 +17,7 @@
 package dgman
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
@@ -48,6 +49,8 @@ type User struct {
 	ReviewDe   string       `json:"review@de"` // should not be parsed
 	Height     *int         `json:"height,omitempty"`
 	IsAdmin    bool         `json:"is_admin,omitempty"`
+	Temp       float64      `json:"temperature,omitempty"`
+	Amount     *big.Float     `json:"amount,omitempty" dgraph:"index=bigfloat"`
 	CustomTime CustomTime   `json:"custom_time,omitempty"`
 	Dob        *time.Time   `json:"dob,omitempty"`
 	Status     EnumType     `json:"status,omitempty" dgraph:"type=int"`
@@ -72,7 +75,7 @@ type Anonymous struct {
 
 type School struct {
 	UID      string   `json:"uid,omitempty"`
-	Name     string   `json:"name,omitempty"`
+	Name     string   `json:"name,omitempty" dgraph:"index=term"`
 	Location *GeoLoc  `json:"location,omitempty" dgraph:"type=geo"` // test passing type
 	DType    []string `json:"dgraph.type"`
 }
@@ -111,6 +114,8 @@ func TestMarshalSchema(t *testing.T) {
 	assert.Equal(t, "custom_time: datetime .", schema["custom_time"].String())
 	assert.Equal(t, "dob: datetime .", schema["dob"].String())
 	assert.Equal(t, "is_admin: bool .", schema["is_admin"].String())
+	assert.Equal(t, "temperature: float .", schema["temperature"].String())
+	assert.Equal(t, "amount: bigfloat @index(bigfloat) .", schema["amount"].String())
 	assert.Equal(t, "created: datetime .", schema["created"].String())
 	assert.Equal(t, "dates: [datetime] .", schema["dates"].String())
 	assert.Equal(t, "dates_ptr: [datetime] .", schema["dates_ptr"].String())

--- a/types.go
+++ b/types.go
@@ -1,0 +1,153 @@
+package dgman
+
+import (
+	"math/big"
+	"time"
+	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+var json = jsoniter.Config{
+	EscapeHTML:             true,
+	SortMapKeys:            true,
+	ValidateJsonRawMessage: true,
+}.Froze()
+
+// timeEncoder is a custom JSON encoder for time.Time values
+type timeEncoder struct{}
+
+func (e *timeEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	return (*time.Time)(ptr).IsZero()
+}
+
+// Encode encodes a time.Time value as a JSON string if not a "Zero" time
+func (e *timeEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	t := *(*time.Time)(ptr)
+	if t.IsZero() {
+		stream.WriteNil()
+	} else {
+		stream.WriteString(t.Format(time.RFC3339))
+	}
+}
+
+type bigFloatEncoder struct{}
+
+func (e *bigFloatEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	f := (*big.Float)(ptr)
+	return f == nil || f.Sign() == 0
+}
+
+func (e *bigFloatEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	f := (*big.Float)(ptr)
+	if f == nil || f.Sign() == 0 {
+		stream.WriteNil()
+	} else {
+		stream.WriteString(f.Text('f', -1))
+	}
+}
+
+type bigFloatDecoder struct{}
+
+func (d *bigFloatDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	switch iter.WhatIsNext() {
+	case jsoniter.NilValue:
+		iter.ReadNil()
+		*(*big.Float)(ptr) = *big.NewFloat(0)
+	case jsoniter.StringValue:
+		str := iter.ReadString()
+		f, _, err := big.ParseFloat(str, 10, 0, big.ToNearestEven)
+		if err != nil {
+			iter.ReportError("decode big.Float", err.Error())
+			return
+		}
+		*(*big.Float)(ptr) = *f
+	case jsoniter.NumberValue:
+		str := iter.ReadNumber().String()
+		f, _, err := big.ParseFloat(str, 10, 0, big.ToNearestEven)
+		if err != nil {
+			iter.ReportError("decode big.Float", err.Error())
+			return
+		}
+		*(*big.Float)(ptr) = *f
+	default:
+		iter.ReportError("decode big.Float", "invalid value type")
+	}
+}
+
+// VectorFloat32 represents a float32vector in Dgraph
+type VectorFloat32 struct {
+	Values []float32
+	Metric string // "cosine", "euclidean", or "dotproduct"
+}
+
+// SchemaType implements SchemaType interface to provide the Dgraph type
+func (v VectorFloat32) SchemaType() string {
+	return "float32vector"
+}
+
+// vectorFloat32Encoder encodes VectorFloat32 as a quoted JSON array string
+type vectorFloat32Encoder struct{}
+
+func (e *vectorFloat32Encoder) IsEmpty(ptr unsafe.Pointer) bool {
+	v := (*VectorFloat32)(ptr)
+	return v == nil || len(v.Values) == 0
+}
+
+func (e *vectorFloat32Encoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	v := (*VectorFloat32)(ptr)
+	if v == nil || len(v.Values) == 0 {
+		stream.WriteNil()
+		return
+	}
+
+	// Convert the Values slice to a JSON array as a string
+	arrayBytes, err := json.Marshal(v.Values)
+	if err != nil {
+		stream.Error = err
+		return
+	}
+
+	// Write the JSON array as a quoted string
+	stream.WriteString(string(arrayBytes))
+}
+
+// vectorFloat32Decoder decodes a quoted JSON array string into VectorFloat32
+type vectorFloat32Decoder struct{}
+
+func (d *vectorFloat32Decoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	v := (*VectorFloat32)(ptr)
+
+	switch iter.WhatIsNext() {
+	case jsoniter.NilValue:
+		iter.ReadNil()
+		v.Values = []float32{}
+	case jsoniter.StringValue:
+		// Handle string-encoded arrays: "[]" or "[1.0,2.0,3.0]"
+		str := iter.ReadString()
+
+		// Strip quotes if they're the outermost characters
+		if len(str) >= 2 && str[0] == '"' && str[len(str)-1] == '"' {
+			str = str[1 : len(str)-1]
+		}
+
+		if err := json.Unmarshal([]byte(str), &v.Values); err != nil {
+			iter.ReportError("decode VectorFloat32", err.Error())
+		}
+	case jsoniter.ArrayValue:
+		// Handle direct array: [] or [1.0,2.0,3.0]
+		var values []float32
+		iter.ReadVal(&values)
+		v.Values = values
+	default:
+		iter.ReportError("decode VectorFloat32", "invalid value type")
+	}
+}
+
+func init() {
+	jsoniter.RegisterTypeEncoder("time.Time", &timeEncoder{})
+	jsoniter.RegisterTypeEncoder("big.Float", &bigFloatEncoder{})
+	jsoniter.RegisterTypeDecoder("big.Float", &bigFloatDecoder{})
+	jsoniter.RegisterTypeEncoder("dgman.VectorFloat32", &vectorFloat32Encoder{})
+	jsoniter.RegisterTypeDecoder("dgman.VectorFloat32", &vectorFloat32Decoder{})
+}

--- a/types.go
+++ b/types.go
@@ -78,7 +78,6 @@ func (d *bigFloatDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 // VectorFloat32 represents a float32vector in Dgraph
 type VectorFloat32 struct {
 	Values []float32
-	Metric string // "cosine", "euclidean", or "dotproduct"
 }
 
 // SchemaType implements SchemaType interface to provide the Dgraph type

--- a/types_test.go
+++ b/types_test.go
@@ -34,6 +34,7 @@ type TestFloats struct {
 
 func TestMutationFloats(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
 
 	_, err := CreateSchema(c, TestFloats{})
 	if err != nil {
@@ -86,17 +87,18 @@ type TestItem struct {
 
 func TestVectorMutation(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
+	defer dropAll(c)
 
 	// Create schema for the test item with vector field
 	schema, err := CreateSchema(c, TestItem{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer dropAll(c)
 
 	// Check the schema
 	assert.Equal(t, "name: string @index(term) .", schema.Schema["name"].String())
-	assert.Equal(t, "identifier: string @index(term) @upsert .", schema.Schema["identifier"].String())
+	assert.Equal(t, "identifier: string @index(term,hash) @upsert @unique .", schema.Schema["identifier"].String())
 	assert.Equal(t, "description: string .", schema.Schema["description"].String())
 	assert.Equal(t, "vector: float32vector @index(hnsw(metric:\"cosine\")) .", schema.Schema["vector"].String())
 
@@ -150,6 +152,8 @@ func TestVectorMutation(t *testing.T) {
 
 func TestVectorMutationEuclidean(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
+	defer dropAll(c)
 
 	// Create a slightly different struct for euclidean metric
 	type EuclideanItem struct {
@@ -201,11 +205,13 @@ func TestVectorMutationEuclidean(t *testing.T) {
 
 func TestVectorSimilaritySearch(t *testing.T) {
 	c := newDgraphClient()
+	dropAll(c)
+	defer dropAll(c)
+
 	_, err := CreateSchema(c, TestItem{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer dropAll(c)
 
 	// Insert several items with different vectors
 	items := []TestItem{

--- a/types_test.go
+++ b/types_test.go
@@ -80,7 +80,7 @@ type TestItem struct {
 	Name        string         `json:"name,omitempty" dgraph:"index=term"`
 	Identifier  string         `json:"identifier,omitempty" dgraph:"index=term unique"`
 	Description string         `json:"description,omitempty"`
-	Vector      *VectorFloat32 `json:"vector,omitempty" dgraph:"index=hnsw(metric=\"cosine\")"`
+	Vector      *VectorFloat32 `json:"vector,omitempty" dgraph:"index=hnsw(metric:\"cosine\")"`
 	DType       []string       `json:"dgraph.type,omitempty" dgraph:"Item"`
 }
 
@@ -113,6 +113,11 @@ func TestVectorMutation(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, uids)
 	assert.NotEmpty(t, item.UID)
+
+	schema, err = CreateSchema(c, TestItem{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Query it back
 	tx = NewReadOnlyTxn(c)
@@ -159,7 +164,7 @@ func TestVectorMutationEuclidean(t *testing.T) {
 		UID        string        `json:"uid,omitempty"`
 		Name       string        `json:"name,omitempty" dgraph:"index=term"`
 		Identifier string        `json:"identifier,omitempty" dgraph:"index=term unique"`
-		Vector     VectorFloat32 `json:"vector" dgraph:"index=hnsw(metric=\"euclidean\")"`
+		Vector     VectorFloat32 `json:"vector" dgraph:"index=hnsw(metric:\"euclidean\")"`
 		DType      []string      `json:"dgraph.type,omitempty" dgraph:"EuclideanItem"`
 	}
 

--- a/types_test.go
+++ b/types_test.go
@@ -32,13 +32,6 @@ type TestFloats struct {
 	DType  []string   `json:"dgraph.type,omitempty"`
 }
 
-func createTestFloats() TestFloats {
-	return TestFloats{
-		Name:   "wildan",
-		Amount: big.NewFloat(100.556),
-	}
-}
-
 func TestMutationFloats(t *testing.T) {
 	c := newDgraphClient()
 
@@ -49,7 +42,10 @@ func TestMutationFloats(t *testing.T) {
 	defer dropAll(c)
 
 	tx := NewTxn(c).SetCommitNow()
-	user := createTestFloats()
+	user := TestFloats{
+		Name:   "wildan",
+		Amount: big.NewFloat(100.556),
+	}
 
 	uids, err := tx.MutateBasic(&user)
 	if err != nil {
@@ -88,18 +84,6 @@ type TestItem struct {
 	DType       []string       `json:"dgraph.type,omitempty" dgraph:"Item"`
 }
 
-func createTestItem() TestItem {
-	return TestItem{
-		Name:        "Test Item",
-		Identifier:  "test-item-1",
-		Description: "This is a test item for vector embeddings",
-		Vector: &VectorFloat32{
-			Values: []float32{0.1, 0.2, 0.3, 0.4, 0.5},
-			Metric: "cosine",
-		},
-	}
-}
-
 func TestVectorMutation(t *testing.T) {
 	c := newDgraphClient()
 
@@ -118,7 +102,12 @@ func TestVectorMutation(t *testing.T) {
 
 	// Create and insert a test item
 	tx := NewTxn(c).SetCommitNow()
-	item := createTestItem()
+	item := TestItem{
+		Name:        "Test Item",
+		Identifier:  "test-item-1",
+		Description: "This is a test item for vector embeddings",
+		Vector:      &VectorFloat32{Values: []float32{0.1, 0.2, 0.3, 0.4, 0.5}},
+	}
 
 	uids, err := tx.MutateBasic(&item)
 	require.NoError(t, err)

--- a/utils.go
+++ b/utils.go
@@ -33,7 +33,7 @@ func newDgraphClient() *dgo.Dgraph {
 	addr = "dgraph://" + addr
 	client, err := dgo.Open(addr)
 	if err != nil {
-		panic(err)
+		panic("Error opening Dgraph client: " + err.Error())
 	}
 
 	return client

--- a/utils.go
+++ b/utils.go
@@ -18,6 +18,7 @@ package dgman
 
 import (
 	"context"
+	"os"
 	"strconv"
 
 	"github.com/dgraph-io/dgo/v240"
@@ -25,7 +26,12 @@ import (
 )
 
 func newDgraphClient() *dgo.Dgraph {
-	client, err := dgo.Open("dgraph://localhost:9080")
+	addr := os.Getenv("DGMAN_TEST_DATABASE")
+	if addr == "" {
+		addr = "localhost:9080"
+	}
+	addr = "dgraph://" + addr
+	client, err := dgo.Open(addr)
 	if err != nil {
 		panic(err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -18,21 +18,11 @@ package dgman
 
 import (
 	"context"
-	"math/big"
 	"strconv"
-	"time"
-	"unsafe"
 
 	"github.com/dgraph-io/dgo/v240"
 	"github.com/dgraph-io/dgo/v240/protos/api"
-	jsoniter "github.com/json-iterator/go"
 )
-
-var json = jsoniter.Config{
-	EscapeHTML:             true,
-	SortMapKeys:            true,
-	ValidateJsonRawMessage: true,
-}.Froze()
 
 func newDgraphClient() *dgo.Dgraph {
 	client, err := dgo.Open("dgraph://localhost:9080")
@@ -87,71 +77,4 @@ func (s set) Remove(value string) {
 func (s set) Has(value string) bool {
 	_, c := s[value]
 	return c
-}
-
-// timeEncoder is a custom JSON encoder for time.Time values
-type timeEncoder struct{}
-
-func (e *timeEncoder) IsEmpty(ptr unsafe.Pointer) bool {
-	return (*time.Time)(ptr).IsZero()
-}
-
-// Encode encodes a time.Time value as a JSON string if not a "Zero" time
-func (e *timeEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
-	t := *(*time.Time)(ptr)
-	if t.IsZero() {
-		stream.WriteNil()
-	} else {
-		stream.WriteString(t.Format(time.RFC3339))
-	}
-}
-
-type bigFloatEncoder struct{}
-
-func (e *bigFloatEncoder) IsEmpty(ptr unsafe.Pointer) bool {
-	f := (*big.Float)(ptr)
-	return f == nil || f.Sign() == 0
-}
-
-func (e *bigFloatEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
-	f := (*big.Float)(ptr)
-	if f == nil || f.Sign() == 0 {
-		stream.WriteNil()
-	} else {
-		stream.WriteString(f.Text('f', -1))
-	}
-}
-
-type bigFloatDecoder struct{}
-
-func (d *bigFloatDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-	switch iter.WhatIsNext() {
-	case jsoniter.NilValue:
-		iter.ReadNil()
-		*(*big.Float)(ptr) = *big.NewFloat(0)
-	case jsoniter.StringValue:
-		str := iter.ReadString()
-		f, _, err := big.ParseFloat(str, 10, 0, big.ToNearestEven)
-		if err != nil {
-			iter.ReportError("decode big.Float", err.Error())
-			return
-		}
-		*(*big.Float)(ptr) = *f
-	case jsoniter.NumberValue:
-		str := iter.ReadNumber().String()
-		f, _, err := big.ParseFloat(str, 10, 0, big.ToNearestEven)
-		if err != nil {
-			iter.ReportError("decode big.Float", err.Error())
-			return
-		}
-		*(*big.Float)(ptr) = *f
-	default:
-		iter.ReportError("decode big.Float", "invalid value type")
-	}
-}
-
-func init() {
-	jsoniter.RegisterTypeEncoder("time.Time", &timeEncoder{})
-	jsoniter.RegisterTypeEncoder("big.Float", &bigFloatEncoder{})
-	jsoniter.RegisterTypeDecoder("big.Float", &bigFloatDecoder{})
 }


### PR DESCRIPTION
This PR
* adds logr support
* updates tests hygiene for most reliable tests
* adds support to inject the `@unique` directive in the Dgraph schema
* adds support for Dgraph's bigfloat and float32vector types
* removes the reliance on logfmt
* enforces the existence of a `dgraph.type` field for schema-bound structs
* 
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added support for Dgraph's bigfloat and float32vector types, enabled the @unique directive, switched to logr for logging, and improved schema and test reliability.

- **New Features**
  - Added big.Float (bigfloat) and VectorFloat32 (float32vector) type support with custom JSON handling.
  - Enabled parsing and injection of the @unique directive in Dgraph schemas.
  - Added a GetSchema function to fetch the current schema from Dgraph.
  - Enforced the presence of a dgraph.type field in schema-bound structs.
  - Switched logging to use the logr package and removed logfmt dependency.

- **Bug Fixes**
  - Updated tests to drop all data before running, reducing test collisions and improving reliability.

<!-- End of auto-generated description by mrge. -->

